### PR TITLE
Recipe tables

### DIFF
--- a/server/models/cuisines.js
+++ b/server/models/cuisines.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Cuisine = sequelize.define( 'Cuisine', 
+  //attributes
+  {
+    name: DataTypes.STRING,
+  });
+
+  return Cuisine;
+}

--- a/server/models/foods.js
+++ b/server/models/foods.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ) {
+  const Food = sequelize.define( 'Food', 
+    //attributes
+    {
+      name: {
+        type: DataTypes.STRING(250),
+        unique: true,
+      },
+    },
+    //options
+    {
+      tableName: 'Foods',
+    });
+
+  Food.associate = function( models ){
+    models.Food.belongsToMany( Food, { as: 'components', foreignKey: 'Food' , through: 'b_foods_self' } );
+    models.Food.hasOne(Food, { as: 'parent' } );
+  }
+  
+  return Food;
+};

--- a/server/models/ingredients.js
+++ b/server/models/ingredients.js
@@ -8,15 +8,21 @@ module.exports = function( sequelize, DataTypes ) {
         type: DataTypes.STRING(250),
         unique: true,
       },
+      amount: DataTypes.INTEGER,
+      optional: {
+        type: DataTypes.BOOLEAN,
+        default: false 
+      }
     },
     //options
     {
-      tableName: 'ingredients',
+      tableName: 'Ingredients',
     });
 
   Ingredient.associate = function( models ){
-    models.Ingredient.belongsToMany( Ingredient, { as: 'components', foreignKey: 'ingredient' , through: 'ingredients_self' } );
-    models.Ingredient.hasOne(Ingredient, {as: 'parent'});
+    models.Ingredient.belongsTo( models.Recipe, { as: 'recipe' } );
+    models.Ingredient.belongsTo( models.Food, { as: 'food' } );
+    models.Ingredient.belongsTo(    models.Unit, { as: 'unit' } );
   }
   
   return Ingredient;

--- a/server/models/instructions.js
+++ b/server/models/instructions.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Instruction = sequelize.define( 'Instruction', 
+  //attributes
+  {
+    index: DataTypes.INTEGER,
+    instruction: DataTypes.STRING
+  });
+
+  return Instruction;
+}

--- a/server/models/recipes.js
+++ b/server/models/recipes.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Recipe = sequelize.define( 'Recipe', 
+  //attributes
+  {
+    name: DataTypes.STRING,
+  },
+  //options
+  );
+
+  Recipe.associate = function( models ){
+    models.Recipe.belongsToMany( models.Instruction, { through: 'b_recipes_instructions' } );
+  }
+
+  return Recipe;
+}

--- a/server/models/recipes.js
+++ b/server/models/recipes.js
@@ -5,12 +5,17 @@ module.exports = function( sequelize, DataTypes ){
   //attributes
   {
     name: DataTypes.STRING,
+    drink: {
+      type: DataTypes.BOOLEAN,
+      default: false
+    }
   },
   //options
   );
 
   Recipe.associate = function( models ){
     models.Recipe.belongsToMany( models.Instruction, { through: 'b_recipes_instructions' } );
+    models.Recipe.belongsTo( models.Cuisine, {as: 'cuisine' } );
   }
 
   return Recipe;

--- a/server/models/units.js
+++ b/server/models/units.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Unit = sequelize.define( 'Unit', 
+  //attributes
+  {
+    name: DataTypes.STRING,
+    type: DataTypes.STRING,
+    amount: DataTypes.INTEGER
+  });
+
+  return Unit;
+}

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -53,7 +53,7 @@ module.exports = function( sequelize, DataTypes ) {
   });
 
   User.associate = function( models ){
-    models.User.belongsToMany( models.Ingredient, { as: 'restrictions', foreignKey: 'user' , through: 'ingredients_users_restrictions' } );
+    models.User.belongsToMany( models.Food, { as: 'restrictions', foreignKey: 'user' , through: 'users_foodrestrictions' } );
   }
 
   /* Set a hook: before creating a row in the User table,


### PR DESCRIPTION
resolves #17 

**The Foods table is for individual elements (eg 'butter')**
Foods table may later contain nutritional value data, etc. 
Foods have a parent_id so a user setting food restrictions can kill an entire hierarchy (e.g. "meat") 
Foods also have a b_foods_self table for more complex food restrictions (to make sure it also kills anything also containing the eliminated items). 

**The Units table is for measurements (e.g. "tablespoon")**
This will be used in recipes as well as likely shopping lists/pantries.  The value of the "amount" column is to be how many 'dashes' (1/16 tsp) in a unit.  The 'amount' column should later facilitate scaling a recipe or doing conversions, or (later) arranging shopping lists and prices.

**The Recipes table can be sorted by cuisine and drink vs meal**
It will later be expanded potentially depending on how insane the meal app suggestions get (I may need to do ala EatThisMuch and have a column for 'is this breakfasty' for example) but let's do that after deciding how Sousanne comes up with meal suggestions) 

**The "Instructions" table is for step by step details**
"Step one, dump everything in bowl" goes here for recipes.  Instructions have an 'index' so users can re-order the instructions after creation.

**The "Ingredients" table provides recipes with the data for "1 tsp of butter", "1 cup of sugar"**