### PR TITLE
Pricebook tables

### DIFF
--- a/server/models/packages.js
+++ b/server/models/packages.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Package = sequelize.define( 'Package', 
+  //attributes
+  {
+    amount: DataTypes.FLOAT,
+    multipack: DataTypes.INTEGER
+  });
+
+  Package.associate = function( models ){
+    models.Package.belongsTo( models.Unit );
+    models.Package.belongsTo( models.Food ); 
+  }
+
+  return Package;
+}

--- a/server/models/pricebooks.js
+++ b/server/models/pricebooks.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Pricebook = sequelize.define( 'Pricebook', 
+  //attributes
+  {
+    //No attributes that aren't created_at or updated_at or ID really.
+  });
+
+  Pricebook.associate = function( models ){
+    models.Pricebook.belongsTo( models.User , { as: 'user' } );
+  }
+
+  return Pricebook;
+}

--- a/server/models/pricebooks.js
+++ b/server/models/pricebooks.js
@@ -5,6 +5,10 @@ module.exports = function( sequelize, DataTypes ){
   //attributes
   {
     //No attributes that aren't created_at or updated_at or ID really.
+    denomination: {
+      type: DataTypes.STRING,
+      default: 'USD'
+    }
   });
 
   Pricebook.associate = function( models ){

--- a/server/models/prices.js
+++ b/server/models/prices.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Price = sequelize.define( 'Price', 
+  //attributes
+  {
+    offerStart: DataTypes.DATE,
+    offerEnd: DataTypes.DATE,
+    discount: DataTypes.INTEGER,
+    price: DataTypes.FLOAT
+  });
+
+  Price.associate = function( models ){
+    models.Price.belongsTo( models.Store );
+    models.Price.belongsTo( models.Product );
+  }
+
+  return Price;
+}

--- a/server/models/products.js
+++ b/server/models/products.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Product = sequelize.define( 'Product', 
+  //attributes
+  {
+    brand: DataTypes.STRING
+  });
+
+  Product.associate = function( models ){
+    models.Product.belongsToMany( models.Store, { through: 'b_products_stores' })
+  }
+
+  return Product;
+}

--- a/server/models/products.js
+++ b/server/models/products.js
@@ -8,7 +8,8 @@ module.exports = function( sequelize, DataTypes ){
   });
 
   Product.associate = function( models ){
-    models.Product.belongsToMany( models.Store, { through: 'b_products_stores' })
+    models.Product.belongsToMany( models.Store, { through: 'b_products_stores' });
+    models.Product.belongsTo( models.Package );
   }
 
   return Product;

--- a/server/models/products.js
+++ b/server/models/products.js
@@ -10,6 +10,7 @@ module.exports = function( sequelize, DataTypes ){
   Product.associate = function( models ){
     models.Product.belongsToMany( models.Store, { through: 'b_products_stores' });
     models.Product.belongsTo( models.Package );
+    models.Product.belongsTo( models.Pricebook );
   }
 
   return Product;

--- a/server/models/stores.js
+++ b/server/models/stores.js
@@ -9,7 +9,7 @@ module.exports = function( sequelize, DataTypes ){
   });
 
   Store.associate = function( models ){
-    models.Store.belongsTo( models.User , { as: 'store' } );
+    models.Store.belongsTo( models.Pricebook , { as: 'pricebook' } );
   }
 
   return Store;

--- a/server/models/stores.js
+++ b/server/models/stores.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function( sequelize, DataTypes ){
+  const Unit = sequelize.define( 'Store', 
+  //attributes
+  {
+    name: DataTypes.STRING,
+    // Perhaps later add location information -- help others out by sharing prices.
+  });
+
+  Store.associate( function( models ) ){
+    models.Store.belongsTo( models.User , { as: 'store' } );
+  } 
+
+  return Store;
+}

--- a/server/models/stores.js
+++ b/server/models/stores.js
@@ -1,16 +1,16 @@
 'use strict';
 
 module.exports = function( sequelize, DataTypes ){
-  const Unit = sequelize.define( 'Store', 
+  const Store = sequelize.define( 'Store', 
   //attributes
   {
     name: DataTypes.STRING,
     // Perhaps later add location information -- help others out by sharing prices.
   });
 
-  Store.associate( function( models ) ){
+  Store.associate = function( models ){
     models.Store.belongsTo( models.User , { as: 'store' } );
-  } 
+  }
 
   return Store;
 }

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -53,7 +53,7 @@ module.exports = function( sequelize, DataTypes ) {
   });
 
   User.associate = function( models ){
-    models.User.belongsToMany( models.Food, { as: 'restrictions', foreignKey: 'user' , through: 'users_foodrestrictions' } );
+    models.User.belongsToMany( models.Food, { as: 'restrictions', foreignKey: 'user' , through: 'b_users_foodrestrictions' } );
   }
 
   /* Set a hook: before creating a row in the User table,


### PR DESCRIPTION
Tables for pricebooks are added in: 

**The "Pricebooks" table:**  
Users have one pricebook each.  Each pricebook has a denomination. 

**The "Packages" table:**
This contains the information for the volume/mass of an item, how many units that item contains, and what food that item is.  E.g. a "4-pack of 5 ounce cans of tuna:"
amount: 5
multipack: 4
unit_id: {id for 'ounce'} 
food_id: {id for 'canned tuna'}

A single 5 ounce can of tuna would have the same information except "0" for multipack.

**The "Products" table:**
Products are packages ("4 pack of 5-oz canned tuna") with a brand name ("Starkist"), each belonging to a single pricebook. This can later provide data about what brand names users are consuming.

**The "Prices" table:**
Prices belong to products (which belong to pricebooks) and have a store attached to them. 

**The "Stores" table:**
Currently only has the name of the store, and belong to individual pricebooks.  